### PR TITLE
fixes bug where process complete log is always printed

### DIFF
--- a/lib/repetitive-task.js
+++ b/lib/repetitive-task.js
@@ -65,15 +65,17 @@ class RepetitiveTask {
         this.logger.info(Object.assign(this._getLogData(task), { task: taskId }), 'processing task')
         processStartTime = process.hrtime()
         return this._process(task)
+          .then(() => {
+            this.logger.info({
+              duration: hrtimeToMs(process.hrtime(processStartTime)),
+              task: taskId
+            }, 'processing complete')
+          })
       })
       .catch((error) => {
         this.logger.error({ stack: error.stack, task: taskId }, 'Error processing task')
       })
       .then(() => {
-        this.logger.info({
-          duration: hrtimeToMs(process.hrtime(processStartTime)),
-          task: taskId
-        }, 'processing complete')
         this.isProcessing = false
         this._queue()
       })


### PR DESCRIPTION
Introduced an issue where, no matter if the process ran or not, the process complete log is always printed. This fixes that. 
